### PR TITLE
Updating Chart Locks - 01828d2a2c9f4b3cd413743e68a4944a

### DIFF
--- a/chart-locks.json
+++ b/chart-locks.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2023-11-10T21:14:38.953350+00:00",
+  "generated": "2023-11-17T16:46:29.487869+00:00",
   "packages": {
     "1946": "partners/redhat-test/1946",
     "3e4r5": "partners/redhat-test/3e4r5",
@@ -196,6 +196,7 @@
     "quarkus": "redhat/redhat/quarkus",
     "rafay-operator-redhat": "partners/rafaysystems/rafay-operator-redhat",
     "rafm": "partners/mobileum/rafm",
+    "redhat-gosnappassredhat": "redhat/redhat/redhat-gosnappassredhat",
     "redhat-nodejs-imagestreams": "redhat/redhat/redhat-nodejs-imagestreams",
     "redhat-perl-imagestreams": "redhat/redhat/redhat-perl-imagestreams",
     "redhat-php-imagestreams": "redhat/redhat/redhat-php-imagestreams",


### PR DESCRIPTION
_This PR was generated by GitHub Actions_

This PR is updating the Chart Locks. The content of this PR was
generated based on the current state of the charts directory.

This PR should be automatically merged by GitHub Actions if there are
no merge conflicts.

The generated lockfile's md5sum is: **01828d2a2c9f4b3cd413743e68a4944a**